### PR TITLE
#23: Fix un-moderated slack invites.

### DIFF
--- a/modules/custom/drupalmel_core/drupalmel_core.rules_defaults.inc
+++ b/modules/custom/drupalmel_core/drupalmel_core.rules_defaults.inc
@@ -100,6 +100,8 @@ function drupalmel_core_default_rules_configuration() {
               "channel" : "#_random",
               "text" : "[entityform:field-first-name] [entityform:field-last-name] ([entityform:field-email-address]) has requested an invitation to Slack.\\r\\n\\r\\nIf you know this individual as DrupalMelbournian, click the following link to approve this request: [site:url]slack-invite\\/[entityform:entityform-id]\\/[entityform:rules_link_token_anonymous]",
               "username" : "melbourne.drupal.org.au",
+              "unfurl_links" : "0",
+              "unfurl_media" : "0",
               "icon_url" : "http:\\/\\/www.gravatar.com\\/avatar\\/31266bcfe7128aaf0854513cf3fa7563"
             },
             "PROVIDE" : { "result" : { "result" : "Result" } }


### PR DESCRIPTION
The current issue appears to be the automatic unfurling of the links in the messages. I tested using http://requestb.in and was only able to reproduce the issue when unfurling was on (or default).
