### PR TITLE
Add Drupal code linter

### DIFF
--- a/.dcr.yml
+++ b/.dcr.yml
@@ -1,0 +1,18 @@
+#
+# DCR configuration file.
+#
+# Run: dcr install or copy manually to your project's root.
+#
+
+# Space (!) separated list of files or directories to scan.
+targets: "modules/custom themes/custom"
+# Comma-separated list of extensions to scan.
+extensions: "module,install,profile,php,theme,inc,test"
+# Comma-separated list of required standards to use.
+standards: "DCR"
+# Space-separated list of phpcs parameters to run dcr.
+parameters: "--colors"
+# Success result message.
+success: "All good! You're awesome!"
+# Fail result message.
+fail: "Please fix errors above and re-run dcr"

--- a/.travis.yml
+++ b/.travis.yml
@@ -81,23 +81,25 @@ mysql:
 
 before_install:
   - composer self-update
-  - cd ./tests
+  - composer require --no-interaction alexdesignworks/dcr:0.0.*
   - composer global require "lionsad/drupal_ti:1.*"
-  - drupal-ti before_install
-
+  - cd $TRAVIS_BUILD_DIR/tests && drupal-ti before_install
 
 install:
   - drupal-ti install
+  - cd $TRAVIS_BUILD_DIR && bash vendor/bin/dcr install
 
 before_script:
-  - drupal-ti --include drupal_ti/scripts/before_script.sh
+  - cd $TRAVIS_BUILD_DIR/tests && drupal-ti --include drupal_ti/scripts/before_script.sh
 
 script:
-  - drupal-ti --include drupal_ti/scripts/script.sh
+  # Lint code.
+  - cd $TRAVIS_BUILD_DIR && source ~/.profile && dcr
+  # Run tests.
+  - cd $TRAVIS_BUILD_DIR/tests && drupal-ti --include drupal_ti/scripts/script.sh
 
 after_script:
-  - drupal-ti after_script
+  - cd $TRAVIS_BUILD_DIR/tests && drupal-ti after_script
 
 notifications:
   email: false
-

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,5 @@
+{
+    "require-dev": {
+        "alexdesignworks/dcr": "0.0.*"
+    }
+}

--- a/dcr_standards/App/ruleset.xml
+++ b/dcr_standards/App/ruleset.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0"?>
+<ruleset name="App">
+  <description>App custom PHP_CodeSniffer standards overrides.</description>
+  <!--
+    Use this ruleset to additionally customise PHPCS.
+    Do not use this standard directly with PHPCS, instead, use DCR standard
+    where this ruleset is already included.
+  -->
+
+  <!--Do not check generated files.-->
+  <exclude-pattern>*\.features\.*</exclude-pattern>
+  <exclude-pattern>*\.strongarm\.*</exclude-pattern>
+  <exclude-pattern>*\.context\.*</exclude-pattern>
+  <exclude-pattern>*\.pages_default\.*</exclude-pattern>
+  <exclude-pattern>*feeds_tamper*\.inc</exclude-pattern>
+
+
+  <!--Allow long arrays in tests for readability.-->
+  <rule ref="Drupal.Array.Array.LongLineDeclaration">
+    <exclude-pattern>*\.test</exclude-pattern>
+  </rule>
+
+  <!--Temporary disabled array indentation until
+  https://www.drupal.org/node/2580017#comment-10456213 is properly fixed. -->
+  <rule ref="Drupal.Array.Array.ArrayIndentation">
+    <exclude-pattern>*.*</exclude-pattern>
+  </rule>
+</ruleset>


### PR DESCRIPTION
1. Added code linter DCR https://github.com/alexdesignworks/dcr (read about how it works on the project page)
2. Configured code linter to only scan custom modules.
3. Custom ruleset allows to easily customise rules on per-project basis (in fact,  skipping of generated files from features, strongarm etc. was configured using this ruleset). It also allows to prevent false positives.
4. Added composer.json with DCR as required dependency to make local installation easier.
5. The CI build will fail if there is at least one code lint problem.
6. The CI build of this PR FAILS because there are code formatting issues in current codebase. It is expected that a new PR will be created to fix those issues OR they can be addressed in this PR (please let me know).

![job__7_3_-_alexdesignworks_drupalmel_-_travis_ci_and_ibis_updates_install_-_ibis_drupal_-___www_ibis_drupal_](https://cloud.githubusercontent.com/assets/378794/11501651/ecc97674-9889-11e5-8062-b4757c3af574.png)
