### PR TITLE
Adds 'page' content type with proper access control

### DIFF
--- a/modules/custom/drupalmel_core/drupalmel_core.features.field_instance.inc
+++ b/modules/custom/drupalmel_core/drupalmel_core.features.field_instance.inc
@@ -521,6 +521,50 @@ function drupalmel_core_field_default_field_instances() {
     ),
   );
 
+  // Exported field_instance: 'node-page-body'
+  $field_instances['node-page-body'] = array(
+    'bundle' => 'page',
+    'default_value' => NULL,
+    'deleted' => 0,
+    'description' => '',
+    'display' => array(
+      'default' => array(
+        'label' => 'hidden',
+        'module' => 'text',
+        'settings' => array(),
+        'type' => 'text_default',
+        'weight' => 0,
+      ),
+      'teaser' => array(
+        'label' => 'hidden',
+        'module' => 'text',
+        'settings' => array(
+          'trim_length' => 600,
+        ),
+        'type' => 'text_summary_or_trimmed',
+        'weight' => 0,
+      ),
+    ),
+    'entity_type' => 'node',
+    'field_name' => 'body',
+    'label' => 'Body',
+    'required' => FALSE,
+    'settings' => array(
+      'display_summary' => TRUE,
+      'text_processing' => 1,
+      'user_register_form' => FALSE,
+    ),
+    'widget' => array(
+      'module' => 'text',
+      'settings' => array(
+        'rows' => 20,
+        'summary_rows' => 5,
+      ),
+      'type' => 'text_textarea_with_summary',
+      'weight' => 31,
+    ),
+  );
+
   // Translatables
   // Included for use with string extractors like potx.
   t('Address');

--- a/modules/custom/drupalmel_core/drupalmel_core.features.inc
+++ b/modules/custom/drupalmel_core/drupalmel_core.features.inc
@@ -130,6 +130,14 @@ function drupalmel_core_node_info() {
       'title_label' => t('Title'),
       'help' => '',
     ),
+    'page' => array(
+      'name' => t('Page'),
+      'base' => 'node_content',
+      'description' => '',
+      'has_title' => '1',
+      'title_label' => t('Title'),
+      'help' => '',
+    ),
   );
   drupal_alter('node_info', $items);
   return $items;

--- a/modules/custom/drupalmel_core/drupalmel_core.features.user_permission.inc
+++ b/modules/custom/drupalmel_core/drupalmel_core.features.user_permission.inc
@@ -29,5 +29,42 @@ function drupalmel_core_user_default_permissions() {
     'module' => 'rules_link',
   );
 
+  // Exported permission: 'create page content'.
+  $permissions['create page content'] = array(
+    'name' => 'create page content',
+    'roles' => array(),
+    'module' => 'node',
+  );
+
+  // Exported permission: 'delete any page content'.
+  $permissions['delete any page content'] = array(
+    'name' => 'delete any page content',
+    'roles' => array(),
+    'module' => 'node',
+  );
+
+  // Exported permission: 'delete own page content'.
+  $permissions['delete own page content'] = array(
+    'name' => 'delete own page content',
+    'roles' => array(),
+    'module' => 'node',
+  );
+
+  // Exported permission: 'edit any page content'.
+  $permissions['edit any page content'] = array(
+    'name' => 'edit any page content',
+    'roles' => array(),
+    'module' => 'node',
+  );
+
+  // Exported permission: 'edit own page content'.
+  $permissions['edit own page content'] = array(
+    'name' => 'edit own page content',
+    'roles' => array(
+      'authenticated user' => 'authenticated user',
+    ),
+    'module' => 'node',
+  );
+
   return $permissions;
 }

--- a/modules/custom/drupalmel_core/drupalmel_core.info
+++ b/modules/custom/drupalmel_core/drupalmel_core.info
@@ -2,7 +2,7 @@ name = DrupalMel core
 description = Core feature for DrupalMel
 core = 7.x
 package = DrupalMel
-version = 7.x-1.0
+version = 7.x-1.1
 
 
 
@@ -120,6 +120,7 @@ features[field_instance][] = node-event-body
 features[field_instance][] = node-event-field_event_address
 features[field_instance][] = node-event-field_event_date
 features[field_instance][] = node-event-field_event_url
+features[field_instance][] = node-page-body
 
 features[filter][] = full_html
 features[filter][] = plain_text
@@ -131,6 +132,7 @@ features[meetup_groups][] = drupalmel
 features[node][] = blog
 features[node][] = blog_feed
 features[node][] = event
+features[node][] = page
 
 features[page_manager_pages][] = homepage
 
@@ -142,6 +144,11 @@ features[rules_link][] = slack_invite_approve
 
 features[user_permission][] = access content
 features[user_permission][] = access rules link slack_invite_approve
+features[user_permission][] = create page content
+features[user_permission][] = delete any page content
+features[user_permission][] = delete own page content
+features[user_permission][] = edit any page content
+features[user_permission][] = edit own page content
 
 features[variable][] = admin_theme
 features[variable][] = blockify_blocks
@@ -156,19 +163,24 @@ features[variable][] = field_bundle_settings_node__event
 features[variable][] = menu_options_blog
 features[variable][] = menu_options_blog_feed
 features[variable][] = menu_options_event
+features[variable][] = menu_options_page
 features[variable][] = menu_parent_blog
 features[variable][] = menu_parent_blog_feed
 features[variable][] = menu_parent_event
+features[variable][] = menu_parent_page
 features[variable][] = node_admin_theme
 features[variable][] = node_options_blog
 features[variable][] = node_options_blog_feed
 features[variable][] = node_options_event
+features[variable][] = node_options_page
 features[variable][] = node_preview_blog
 features[variable][] = node_preview_blog_feed
 features[variable][] = node_preview_event
+features[variable][] = node_preview_page
 features[variable][] = node_submitted_blog
 features[variable][] = node_submitted_blog_feed
 features[variable][] = node_submitted_event
+features[variable][] = node_submitted_page
 features[variable][] = page_cache_maximum_age
 features[variable][] = pathauto_node_event_pattern
 features[variable][] = prepro

--- a/modules/custom/drupalmel_core/drupalmel_core.strongarm.inc
+++ b/modules/custom/drupalmel_core/drupalmel_core.strongarm.inc
@@ -142,6 +142,15 @@ function drupalmel_core_strongarm() {
   $strongarm = new stdClass();
   $strongarm->disabled = FALSE; /* Edit this to true to make a default strongarm disabled initially */
   $strongarm->api_version = 1;
+  $strongarm->name = 'menu_options_page';
+  $strongarm->value = array(
+    0 => 'main-menu',
+  );
+  $export['menu_options_page'] = $strongarm;
+
+  $strongarm = new stdClass();
+  $strongarm->disabled = FALSE; /* Edit this to true to make a default strongarm disabled initially */
+  $strongarm->api_version = 1;
   $strongarm->name = 'menu_parent_blog';
   $strongarm->value = 'main-menu:0';
   $export['menu_parent_blog'] = $strongarm;
@@ -159,6 +168,13 @@ function drupalmel_core_strongarm() {
   $strongarm->name = 'menu_parent_event';
   $strongarm->value = 'main-menu:0';
   $export['menu_parent_event'] = $strongarm;
+
+  $strongarm = new stdClass();
+  $strongarm->disabled = FALSE; /* Edit this to true to make a default strongarm disabled initially */
+  $strongarm->api_version = 1;
+  $strongarm->name = 'menu_parent_page';
+  $strongarm->value = 'main-menu:0';
+  $export['menu_parent_page'] = $strongarm;
 
   $strongarm = new stdClass();
   $strongarm->disabled = FALSE; /* Edit this to true to make a default strongarm disabled initially */
@@ -197,6 +213,15 @@ function drupalmel_core_strongarm() {
   $strongarm = new stdClass();
   $strongarm->disabled = FALSE; /* Edit this to true to make a default strongarm disabled initially */
   $strongarm->api_version = 1;
+  $strongarm->name = 'node_options_page';
+  $strongarm->value = array(
+    0 => 'status',
+  );
+  $export['node_options_page'] = $strongarm;
+
+  $strongarm = new stdClass();
+  $strongarm->disabled = FALSE; /* Edit this to true to make a default strongarm disabled initially */
+  $strongarm->api_version = 1;
   $strongarm->name = 'node_preview_blog';
   $strongarm->value = '1';
   $export['node_preview_blog'] = $strongarm;
@@ -218,6 +243,13 @@ function drupalmel_core_strongarm() {
   $strongarm = new stdClass();
   $strongarm->disabled = FALSE; /* Edit this to true to make a default strongarm disabled initially */
   $strongarm->api_version = 1;
+  $strongarm->name = 'node_preview_page';
+  $strongarm->value = '0';
+  $export['node_preview_page'] = $strongarm;
+
+  $strongarm = new stdClass();
+  $strongarm->disabled = FALSE; /* Edit this to true to make a default strongarm disabled initially */
+  $strongarm->api_version = 1;
   $strongarm->name = 'node_submitted_blog';
   $strongarm->value = 0;
   $export['node_submitted_blog'] = $strongarm;
@@ -235,6 +267,13 @@ function drupalmel_core_strongarm() {
   $strongarm->name = 'node_submitted_event';
   $strongarm->value = 0;
   $export['node_submitted_event'] = $strongarm;
+
+  $strongarm = new stdClass();
+  $strongarm->disabled = FALSE; /* Edit this to true to make a default strongarm disabled initially */
+  $strongarm->api_version = 1;
+  $strongarm->name = 'node_submitted_page';
+  $strongarm->value = 1;
+  $export['node_submitted_page'] = $strongarm;
 
   $strongarm = new stdClass();
   $strongarm->disabled = FALSE; /* Edit this to true to make a default strongarm disabled initially */


### PR DESCRIPTION
This adds a basic content type called page with default fields: title and body.

Also sets permission to allow authenticated users to edit their own content.

This way a basic workflow like this would be possible:
1. A member wants to publish a content. (sends request on Slack or creates an Issue on github)
2. Admin creates an account for the member.
3. Admin creates a content and sets the content author as the username of the new user.
4. Member logs in and edit the contents.
