### PR TITLE
Removed PHP 5.4 from build matrix.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: php
 sudo: false
 
 php:
-  - 5.4
   - 5.5
   - 5.6
 


### PR DESCRIPTION
PHP 5.4 is very old now and should not be used in builds. It also triggers issues with using `drush`.
